### PR TITLE
fix link to previous csasdowntex in readme

### DIFF
--- a/README-FR.md
+++ b/README-FR.md
@@ -10,7 +10,7 @@ csasdown est un package R permettant de produire des documents reproductibles co
 
 Le package applique les exigences de mise en forme établies par le [Secrétariat canadien des avis scientifiques (SCAS)](https://www.dfo-mpo.gc.ca/csas-sccs/index-fra.htm), offre une prise en charge bilingue intégrée (français/anglais) et respecte les normes d'accessibilité requises pour les soumissions au SCAS.
 
-La version originale de csasdown, axée sur les sorties LaTeX et PDF, est toujours disponible sous le nom de [csasdowntex](https://github.com/pbs-assess/csasdown). Elle peut être utilisée pour reproduire des rapports antérieurs ou pour créer des Rapports techniques, mais ne doit pas être utilisée pour la soumission de nouveaux Documents de recherche ou de Réponses des sciences au SCCS.
+La version originale de csasdown, axée sur les sorties LaTeX et PDF, est toujours disponible sous le nom de [csasdowntex](https://github.com/pbs-assess/csasdowntex). Elle peut être utilisée pour reproduire des rapports antérieurs ou pour créer des Rapports techniques, mais ne doit pas être utilisée pour la soumission de nouveaux Documents de recherche ou de Réponses des sciences au SCCS.
 
 *This README file is also [available in English](README.md).*
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ csasdown is an R package for producing reproducible CSAS-compliant documents usi
 
 The package enforces formatting requirements set by the [Canadian Science Advisory Secretariat (CSAS)](https://www.dfo-mpo.gc.ca/csas-sccs/index-eng.htm), includes built-in bilingual (English/French) support, and meets accessibility standards required for CSAS submissions.
 
-The original csasdown, which focused on LaTeX and PDF output, is still available as [csasdowntex](https://github.com/pbs-assess/csasdown) and can be used to reproduce legacy reports or create Technical Reports. It should not be used for submitting new CSAS Research Documents or Science Responses.
+The original csasdown, which focused on LaTeX and PDF output, is still available as [csasdowntex](https://github.com/pbs-assess/csasdowntex) and can be used to reproduce legacy reports or create Technical Reports. It should not be used for submitting new CSAS Research Documents or Science Responses.
 
 *Ce fichier README est également [disponible en français](README-FR.md).*
 


### PR DESCRIPTION
Fix the link to the previous version of CSAS down in the readme markdown.